### PR TITLE
Add Dockerfile and usage instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+      software-properties-common && \
+    add-apt-repository -y ppa:team-gcc-arm-embedded/ppa && \
+    apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+      git make cmake python3 \
+      gcc-arm-embedded && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Project sources volume should be mounted at /app
+WORKDIR /app
+
+ENTRYPOINT ["python3", "build.py"]

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This repository is provides the tooling needed to compile a C/C++ CODAL program 
 ## Raising Issues
 Any issues regarding the micro:bit are gathered on the [lancaster-university/codal-microbit-v2](https://github.com/lancaster-university/codal-microbit-v2) repository. Please raise yours there too.
 
-## Installation
+# Installation
 You need some open source pre-requisites to build this repo. You can either install these tools yourself, or use the docker image provided below.
 
-  - [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
-  - [Github desktop](https://desktop.github.com/)
-  - [CMake](https://cmake.org/download/)
-  - [Python 3](https://www.python.org/downloads/)
+- [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+- [Github desktop](https://desktop.github.com/)
+- [CMake](https://cmake.org/download/)
+- [Python 3](https://www.python.org/downloads/)
 
 We use Ubuntu Linux for most of our tests. You can also install these tools easily through the package manager:
 
@@ -22,14 +22,35 @@ We use Ubuntu Linux for most of our tests. You can also install these tools easi
     sudo apt install gcc-arm-none-eabi binutils-arm-none-eabi
 ```
 
+## Yotta
+For backwards compatibility with [microbit-samples](https://github.com/lancaster-university/microbit-samples) users, we also provide a yotta target for this repository.
 
-### Yotta
-For backwards compatibility with [microbit-samples](https://www.github.com/lancaster-univrsity/microbit-samples) users, we also provide a yotta target for this repository.
+## Docker
+You can use the [Dockerfile](https://github.com/lancaster-university/microbit-v2-samples/blob/master/Dockerfile) provided to build the samples, or your own project sources, without installing additional dependencies.
+
+Run the following command to build the image locally:
+
+```
+    docker build -t microbit-tools .
+```
 
 # Building
 - Clone this repository
 - In the root of this repository type `python build.py`
 - The hex file will be built `MICROBIT.HEX` and placed in the root folder.
+
+## Docker
+You can use the image you built previously to build the project sources in the current working directory (equivalent to executing `build.py`).
+
+```
+    docker run -v $(pwd):/app --rm microbit-tools
+```
+
+You can also provide additional arguments like `--clean`.
+
+```
+    docker run -v $(pwd):/app --rm microbit-tools --clean
+```
 
 # Developing
 You will find a simple main.cpp in the `source` folder which you can edit. CODAL will also compile any other C/C++ header files our source files with the extension `.h .c .cpp` it finds in the source folder.
@@ -37,7 +58,7 @@ You will find a simple main.cpp in the `source` folder which you can edit. CODAL
 The `samples` folder contains a number of simple sample programs that utilise you may find useful.
 
 # Compatibility
-This repository is designed to follow the principles and APIs developed for the first version of the micro:bit. We have also included a compatilibty layer so that the vast majority of C/C++ programs built using [microbit-dal](https://www.github.com/lancaster-university/microbit-dal) will operate with few changes. 
+This repository is designed to follow the principles and APIs developed for the first version of the micro:bit. We have also included a compatilibty layer so that the vast majority of C/C++ programs built using [microbit-dal](https://www.github.com/lancaster-university/microbit-dal) will operate with few changes.
 
 # Documentation
-API documentation is embedded in the code using doxygen. We will produce integrated web-based documetation soon. 
+API documentation is embedded in the code using doxygen. We will produce integrated web-based documetation soon.


### PR DESCRIPTION
I saw the issue about the missing Dockerfile so decided to add one 😄 

- Add a Dockerfile which builds an image based on Ubuntu 20.04 including all of the micro:bit compiliation pre-requisites
- Add usage instructions to the README
- Fix a typo in the README for the link to the v1 samples

Closes #7 