### PR TITLE
VSCode Debug Config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+    "configurations": [
+        {
+            "name": "micro:bit cortex debug",
+            "cwd": "${workspaceFolder}",
+            "executable": "${workspaceFolder}/build/MICROBIT",
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "pyocd",
+            "interface": "swd",
+            "device": "nrf52",
+            "targetId": "nrf52",
+            "runToMain": false,
+            "boardId": "9904",
+            "svdFile": "${workspaceFolder}/libraries/codal-nrf52/nrfx/mdk/nrf52833.svd",
+            "preLaunchCommands": [
+              "load",
+              "add-symbol-file ${workspaceFolder}/build/MICROBIT",
+              "enable breakpoint",
+              "monitor reset"
+            ]
+        },
+
+        {
+            "name": "micro:bit openOCD cortex debug",
+            "cwd": "${workspaceFolder}",
+            "executable": "${workspaceFolder}/build/MICROBIT",
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            "configFiles": ["${workspaceFolder}/openocd.cfg"],
+            "interface": "swd",
+            "device": "nrf52",
+            "targetId": "nrf52",
+            "runToMain": false,
+            "boardId": "9904",
+            "svdFile": "${workspaceFolder}/libraries/codal-nrf52/nrfx/mdk/nrf52833.svd",
+            "preLaunchCommands": [
+              "load",
+              "add-symbol-file ${workspaceFolder}/build/MICROBIT",
+              "enable breakpoint",
+              "monitor reset"
+            ]
+        }
+    ]
+}

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,0 +1,2 @@
+source [find interface/cmsis-dap.cfg]
+source [find target/nrf52.cfg]


### PR DESCRIPTION
Configuration for setting up a baseline debugging environment for the micro:bit for PyOCD and OpenOCD.

As of yet has some difficulty reading local variables but can set breakpoints, read peripheral registers and core registers.