### PR TITLE
CI: Always build with Arm GCC v7 and latest release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-latest, windows-2016]
-        gcc: ['7-2017-q4', '10-2020-q4']
+        gcc: ['7-2017-q4', 'latest']
         cmake: ['3.6.0', '3.21.3']
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Now that CODAL builds with the latest GCC versions we can change the CI config to also build with the latest available release (together with an older one). This should help to catch earlier any issues with new GCC releases. 
