### PR TITLE
CI: Update GitHub Actions Windows image to 2019.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build-py-script:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-2016]
+        os: [ubuntu-18.04, macos-latest, windows-2019]
         gcc: ['7-2017-q4', 'latest']
         cmake: ['3.6.0', '3.21.3']
       fail-fast: false


### PR DESCRIPTION
The 2016 image has been deprecated and removed.