### PR TITLE
Remove unnecessary use of global images in samples to save memory.

### DIFF
--- a/source/samples/DisplayTest.cpp
+++ b/source/samples/DisplayTest.cpp
@@ -50,9 +50,6 @@ const char * const sad_emoji ="\
     000,255,255,255,000\n\
     255,000,000,000,255\n";
 
-Image happy(happy_emoji);
-Image sad(sad_emoji);
-
 static void
 concurrent_display_test_t1()
 {

--- a/source/samples/PowerManagementTest.cpp
+++ b/source/samples/PowerManagementTest.cpp
@@ -24,10 +24,6 @@
     000,255,255,255,000\n\
     000,255,255,255,000\n";
 
-    static MicroBitImage dc(dc_emoji);
-    static MicroBitImage usb(usb_emoji);
-    static MicroBitImage battery(battery_emoji);
-
 void
 version_test()
 {
@@ -134,6 +130,10 @@ usb_connection_test()
 void
 power_source_test()
 {
+    MicroBitImage dc(dc_emoji);
+    MicroBitImage usb(usb_emoji);
+    MicroBitImage battery(battery_emoji);
+
     while(1)
     {
         MicroBitPowerSource p = uBit.power.getPowerSource();


### PR DESCRIPTION
Working on a side project I was looking at the memory map file for the default build and noticed a couple of functions/globals from unused samples that are somehow left inside the build, mostly a few global `MicroBitImage` and, I'm not sure how, but also a couple of uncalled functions: `version_test` and `display_wink`.

Some exerpts from the memory map file:

```
 .text.startup._GLOBAL__sub_I__Z12version_testv
                0x0000000000002c14       0x64 CMakeFiles/MICROBIT.dir/source/samples/PowerManagementTest.cpp.obj


 .rodata._Z12display_winkv.str1.4
                0x0000000000014624      0x105 CMakeFiles/MICROBIT.dir/source/samples/DisplayTest.cpp.obj
 .rodata._GLOBAL__sub_I_happy.str1.4
                0x000000000001472c       0x79 CMakeFiles/MICROBIT.dir/source/samples/DisplayTest.cpp.obj
 .rodata._GLOBAL__sub_I__Z12version_testv.str1.4
                0x000000000001523c      0x171 CMakeFiles/MICROBIT.dir/source/samples/PowerManagementTest.cpp.obj



 .bss.happy     0x0000000020001634        0x4 CMakeFiles/MICROBIT.dir/source/samples/DisplayTest.cpp.obj
                0x0000000020001634                happy
 .bss.sad       0x0000000020001638        0x4 CMakeFiles/MICROBIT.dir/source/samples/DisplayTest.cpp.obj
                0x0000000020001638                sad
 .bss._ZL2dc    0x00000000200016b0        0x4 CMakeFiles/MICROBIT.dir/source/samples/PowerManagementTest.cpp.obj
 .bss._ZL3usb   0x00000000200016b4        0x4 CMakeFiles/MICROBIT.dir/source/samples/PowerManagementTest.cpp.obj
 .bss._ZL7battery
                0x00000000200016b8        0x4 CMakeFiles/MICROBIT.dir/source/samples/PowerManagementTest.cpp.obj


 .ARM.attributes
                0x00000000000000d0       0x32 CMakeFiles/MICROBIT.dir/source/samples/DisplayTest.cpp.obj
 .ARM.attributes
                0x0000000000000166       0x32 CMakeFiles/MICROBIT.dir/source/samples/PowerManagementTest.cpp.obj
```

The minor modifications from this PR removes this unused data/code from the build, which saves 20 bytes of RAM and close to 1KB of flash:

```bash
# Before
$ arm-none-eabi-size build/MICROBIT
   text    data     bss     dec     hex filename
 216008       8    7164  223180   367cc build/MICROBIT

# After
$ arm-none-eabi-size build/MICROBIT
   text    data     bss     dec     hex filename
 215092       8    7144  222244   36424 build/MICROBIT
```
