### PR TITLE
Fix build.py --clean flag does actually clean with Ninja on Windows.

### DIFF
--- a/utils/python/codal_utils.py
+++ b/utils/python/codal_utils.py
@@ -19,6 +19,9 @@ def build(clean, verbose = False):
         # configure
         system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Ninja\"")
 
+        if clean:
+            system("ninja clean")
+
         # build
         if verbose:
             system("ninja --verbose")


### PR DESCRIPTION
@JohnVidler another small easy PR, basically adds a missing `ninja clean` command.

Upstream codal PR:
- https://github.com/lancaster-university/codal/pull/51