### PR TITLE
CI: Also build BLE project.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,24 @@ name: Build Natively
 
 on:
   push:
-    branches: [ master ]
+    branches: '*'
   pull_request:
-    branches: [ master ]
+    branches: '*'
 
 jobs:
   build-py-script:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-18.04, macos-11, windows-2019]
         gcc: ['7-2017-q4', 'latest']
         cmake: ['3.6.0', '3.21.3']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}, gcc ${{ matrix.gcc }}, cmake ${{ matrix.cmake || 'latest'}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Setup arm-none-eabi-gcc ${{ matrix.gcc }}
@@ -38,8 +38,17 @@ jobs:
           cmake --version
           ninja --version
           python --version
-      - name: Build using build.py
+      - name: Build default project using build.py
         run: python build.py
+      - name: Prepare BLE example
+        run: |
+          rm codal.json
+          mv codal.ble.json codal.json
+          python -c "import pathlib; \
+            f=pathlib.Path('source/main.cpp'); \
+            f.write_text(f.read_text().replace('out_of_box_experience()', 'ble_test()'))"
+      - name: Build BLE project using build.py
+        run: python build.py --clean
       - name: Upload hex file
         uses: actions/upload-artifact@v1
         with:

--- a/codal.ble.json
+++ b/codal.ble.json
@@ -8,7 +8,6 @@
         "dev": true
     } ,
     "config":{
-        "SOFTDEVICE_PRESENT": 1,
         "DEVICE_BLE": 1,
         "MICROBIT_BLE_ENABLED" : 1,
         "MICROBIT_BLE_PAIRING_MODE": 1,


### PR DESCRIPTION
@JohnVidler this way the CI builds a BLE enabled project as well with the older/newer CMake and gcc versions, which would have helped us catch the MakeCode build issue earlier.

Currently this will fail the jobs running CMake v3.6, as expected.