### PR TITLE
Suggestion:  Safer codal.json for users & create codal.dev.json for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ You will find a simple main.cpp in the `source` folder which you can edit. CODAL
 
 The `samples` folder contains a number of simple sample programs that utilise you may find useful.
 
+## Developer codal.json
+
+There is an example `coda.dev.json` file which enables "developer builds" (clones dependencies from the latest commits, instead of the commits locked in the `codal-microbit-v2` tag), and adds extra CODAL flags that enable debug data to be printed to serial.
+To use it, simply copy the additional json entries into your `codal.json` file, or you can replace the file completely (`mv coda.dev.json codal.json`).
+
 # Debugging
 If you are using Visual Studio Code, there is a working debugging environment already set up for you, allowing you to set breakpoints and observe the micro:bit's memory. To get it working, follow these steps:
 

--- a/codal.ble.json
+++ b/codal.ble.json
@@ -3,9 +3,7 @@
         "name": "codal-microbit-v2",
         "url": "https://github.com/lancaster-university/codal-microbit-v2",
         "branch": "master",
-        "type": "git",
-        "test_ignore": true,
-        "dev": true
+        "type": "git"
     } ,
     "config":{
         "DEVICE_BLE": 1,
@@ -14,7 +12,7 @@
         "MICROBIT_BLE_DFU_SERVICE": 1,
         "MICROBIT_BLE_DEVICE_INFORMATION_SERVICE": 1,
         "MICROBIT_BLE_EVENT_SERVICE" : 1,
-        "MICROBIT_BLE_PARTIAL_FLASHING" : 0,
+        "MICROBIT_BLE_PARTIAL_FLASHING" : 1,
         "MICROBIT_BLE_SECURITY_LEVEL": "SECURITY_MODE_ENCRYPTION_NO_MITM"
     }
 }

--- a/codal.dev.json
+++ b/codal.dev.json
@@ -3,9 +3,13 @@
         "name": "codal-microbit-v2",
         "url": "https://github.com/lancaster-university/codal-microbit-v2",
         "branch": "master",
-        "type": "git"
+        "type": "git",
+        "dev": true
     },
     "config":{
+        "DEVICE_DMESG": 1,
+        "DMESG_SERIAL_DEBUG": 1,
+        "CODAL_DEBUG": 1,
         "MICROBIT_BLE_ENABLED" : 0,
         "MICROBIT_BLE_PAIRING_MODE": 0,
         "CONFIG_MICROBIT_ERASE_USER_DATA_ON_REFLASH": 1

--- a/codal.dev.json
+++ b/codal.dev.json
@@ -8,6 +8,7 @@
     },
     "config":{
         "DEVICE_DMESG": 1,
+        "DEVICE_DMESG_BUFFER_SIZE": 1024,
         "DMESG_SERIAL_DEBUG": 1,
         "CODAL_DEBUG": 1,
         "MICROBIT_BLE_ENABLED" : 0,


### PR DESCRIPTION
The current `codal.json`:
- Has the "dev" option enabled, that clones the main branch from all libraries, which is a bit risky for the average user. The locked target commits should be safer.
    - Also, changing the value to "false" doesn't actually work, so it can be confusing as well
    - https://github.com/lancaster-university/microbit-v2-samples/issues/63
- Enables debug messages, which are good for debugging, but odd for normal users, who might not expect to see additional data being sent to serial and might not know how to turn it off (it's not really documented anywhere)


This settings are useful for CODAL development, so I suggest to keep them in a new separate `codal.dev.json` (like `codal.ble.json`), so that devs can simply `mv codal.dev.json codal.json` after cloning. 

This way we leave a safer `codal.json` configuration for normal users that might just want to create a CODAL C++ micro:bit programme.

-----

This PR also remove the `test_ignore` key because it's used by `build.py` only when found in the `utils/targets.json` file. It probably was accidentally added from copy/pasting the config from `utils/targets.json`.

Also enables partial flashing on `codal.ble.json`, which we should probably have on by default.