### PR TITLE
Rename DEVICE_DMESG to DMESG_ENABLE.

### DIFF
--- a/codal.dev.json
+++ b/codal.dev.json
@@ -7,7 +7,7 @@
         "dev": true
     },
     "config":{
-        "DEVICE_DMESG": 1,
+        "DMESG_ENABLE": 1,
         "DEVICE_DMESG_BUFFER_SIZE": 1024,
         "DMESG_SERIAL_DEBUG": 1,
         "CODAL_DEBUG": 1,


### PR DESCRIPTION
As part of:
- https://github.com/lancaster-university/codal-microbit-v2/issues/297

And as described in https://github.com/lancaster-university/codal-microbit-v2/issues/297#issuecomment-1516305298.