### PR TITLE
SerialStreamer: Don't output a tab after each buffer in stream binary mode.

### DIFF
--- a/source/samples/SerialStreamer.cpp
+++ b/source/samples/SerialStreamer.cpp
@@ -87,8 +87,6 @@ void SerialStreamer::streamBuffer(ManagedBuffer buffer)
 
         while(p < end)
             uBit.serial.putc(*p++);
-        
-        uBit.serial.putc('\t');
     }
 
     // if a HEX mode is requested, format using printf, framed by sample size..


### PR DESCRIPTION
When raw data is captured and the tab (ascii value 9) is present in the data file, it produces a sound glitch.

As shown in the bottom waveform here:
![image](https://github.com/lancaster-university/microbit-v2-samples/assets/29712657/a14a5154-71c7-4db4-9c44-8e56f6907f89)


Fixes https://github.com/lancaster-university/codal-microbit-v2/issues/342.