### PR TITLE
[Clang compatibility] Added Clang CMake definitions.

### DIFF
--- a/utils/cmake/toolchains/CLANG/bin-generator.cmake
+++ b/utils/cmake/toolchains/CLANG/bin-generator.cmake
@@ -1,0 +1,9 @@
+add_custom_command(
+    OUTPUT "${PROJECT_SOURCE_DIR}/${codal.output_folder}/${device.device}.bin"
+    COMMAND "${LLVM_OBJCOPY}" -O binary "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${device.device}" "${PROJECT_SOURCE_DIR}/${codal.output_folder}/${device.device}.bin"
+    DEPENDS  ${device.device}
+    COMMENT "converting to bin file."
+)
+
+#specify a dependency on the elf file so that bin is automatically rebuilt when elf is changed.
+add_custom_target(${device.device}_bin ALL DEPENDS "${PROJECT_SOURCE_DIR}/${codal.output_folder}/${device.device}.bin")

--- a/utils/cmake/toolchains/CLANG/compiler-flags.cmake
+++ b/utils/cmake/toolchains/CLANG/compiler-flags.cmake
@@ -1,0 +1,49 @@
+set(EXPLICIT_INCLUDES "")
+if((CMAKE_VERSION VERSION_GREATER "3.4.0") OR (CMAKE_VERSION VERSION_EQUAL "3.4.0"))
+    # from CMake 3.4 <INCLUDES> are separate to <FLAGS> in the
+    # CMAKE_<LANG>_COMPILE_OBJECT, CMAKE_<LANG>_CREATE_ASSEMBLY_SOURCE, and
+    # CMAKE_<LANG>_CREATE_PREPROCESSED_SOURCE commands
+    set(EXPLICIT_INCLUDES "<INCLUDES> ")
+endif()
+
+# Override the link rules:
+set(CMAKE_C_CREATE_SHARED_LIBRARY "echo 'shared libraries not supported' && 1")
+set(CMAKE_C_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
+set(CMAKE_C_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr <LINK_FLAGS> <TARGET> <OBJECTS>")
+set(CMAKE_C_COMPILE_OBJECT        "<CMAKE_C_COMPILER> <DEFINES> ${EXPLICIT_INCLUDES}<FLAGS> -o <OBJECT> -c <SOURCE>")
+
+set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_C_COMPILER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> -Wl,-Map,<TARGET>.map -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> -lm -lc -lgcc -lm -lc -lgcc -Wl,--end-group --specs=nano.specs -o <TARGET>")
+
+set(CMAKE_CXX_OUTPUT_EXTENSION ".o")
+set(CMAKE_DEPFILE_FLAGS_CXX "-MMD -MT <OBJECT> -MF <DEPFILE>")
+set(CMAKE_C_OUTPUT_EXTENSION ".o")
+set(CMAKE_DEPFILE_FLAGS_C "-MMD -MT <OBJECT> -MF <DEPFILE>")
+
+set(CMAKE_C_FLAGS_DEBUG_INIT          "-g -gdwarf-3")
+set(CMAKE_C_FLAGS_MINSIZEREL_INIT     "-Os -DNDEBUG")
+set(CMAKE_C_FLAGS_RELEASE_INIT        "-Os -DNDEBUG")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-Os -g -gdwarf-3 -DNDEBUG")
+set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-isystem ")
+
+
+set(CMAKE_ASM_FLAGS_DEBUG_INIT          "-g -gdwarf-3")
+set(CMAKE_ASM_FLAGS_MINSIZEREL_INIT     "-Os -DNDEBUG")
+set(CMAKE_ASM_FLAGS_RELEASE_INIT        "-Os -DNDEBUG")
+set(CMAKE_ASM_FLAGS_RELWITHDEBINFO_INIT "-Os -g -gdwarf-3 -DNDEBUG")
+set(CMAKE_INCLUDE_SYSTEM_FLAG_ASM  "-isystem ")
+
+set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr <LINK_FLAGS> <TARGET> <OBJECTS>")
+
+set(CMAKE_CXX_LINK_EXECUTABLE       "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> -Wl,-Map,<TARGET>.map -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> -lnosys -lstdc++ -lsupc++ -lm -lc -lgcc -lstdc++ -lsupc++ -lm -lc -lgcc -Wl,--end-group  --specs=nano.specs -o <TARGET>")
+
+set(CMAKE_CXX_FLAGS_DEBUG_INIT          "-g -gdwarf-3")
+set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT     "-Os -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT        "-Os -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-Os -g -gdwarf-3 -DNDEBUG")
+set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
+
+if (CMAKE_C_COMPILER_VERSION VERSION_GREATER "7.1.0" OR CMAKE_C_COMPILER_VERSION VERSION_EQUAL "7.1.0")
+    message("${BoldRed}Supressing -Wexpansion-to-defined.${ColourReset}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-expansion-to-defined")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-expansion-to-defined")
+endif ()

--- a/utils/cmake/toolchains/CLANG/hex-generator.cmake
+++ b/utils/cmake/toolchains/CLANG/hex-generator.cmake
@@ -1,0 +1,9 @@
+add_custom_command(
+    OUTPUT "${PROJECT_SOURCE_DIR}/${codal.output_folder}/${device.device}.hex"
+    COMMAND "${LLVM_OBJCOPY}" -O ihex "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${device.device}" "${PROJECT_SOURCE_DIR}/${codal.output_folder}/${device.device}.hex"
+    DEPENDS  ${device.device}
+    COMMENT "converting to hex file."
+)
+
+#specify a dependency on the elf file so that hex is automatically rebuilt when elf is changed.
+add_custom_target(${device.device}_hex ALL DEPENDS "${PROJECT_SOURCE_DIR}/${codal.output_folder}/${device.device}.hex")

--- a/utils/cmake/toolchains/CLANG/platform_includes.h
+++ b/utils/cmake/toolchains/CLANG/platform_includes.h
@@ -1,0 +1,10 @@
+#ifndef PLATFORM_INCLUDES
+#define PLATFORM_INCLUDES
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <math.h>
+
+#endif

--- a/utils/cmake/toolchains/CLANG/toolchain.cmake
+++ b/utils/cmake/toolchains/CLANG/toolchain.cmake
@@ -1,0 +1,29 @@
+find_program(LLVM_RANLIB llvm-ranlib)
+find_program(LLVM_AR llvm-ar)
+find_program(CLANG clang)
+find_program(CLANG++ clang++)
+find_program(LLVM_OBJCOPY llvm-objcopy)
+
+set(CMAKE_OSX_SYSROOT "/")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "")
+
+set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_SYSTEM_VERSION "2.0.0")
+
+set(CODAL_TOOLCHAIN "CLANG")
+
+if(CMAKE_VERSION VERSION_LESS "3.5.0")
+    include(CMakeForceCompiler)
+    cmake_force_c_compiler("${CLANG}" GNU)
+    cmake_force_cxx_compiler("${CLANG++}" GNU)
+else()
+    # from 3.5 the force_compiler macro is deprecated: CMake can detect
+    # llvm-gcc as being a GNU compiler automatically
+	set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+    set(CMAKE_C_COMPILER "${CLANG}")
+    set(CMAKE_CXX_COMPILER "${CLANG++}")
+endif()
+
+SET(CMAKE_AR "${LLVM_AR}" CACHE FILEPATH "Archiver")
+SET(CMAKE_RANLIB "${LLVM_RANLIB}" CACHE FILEPATH "rlib")
+set(CMAKE_CXX_OUTPUT_EXTENSION ".o")


### PR DESCRIPTION
Able to change the compiler used in target.json to CLANG now, this will build using clang (atleast up to the libraries) given some other changes, such as setting the flag--target=arm-none-eabi.