### PR TITLE
CI: Print to job summary the cppcheck output.

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -29,6 +29,12 @@ jobs:
         run: |
           cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
           cppcheck --project=compile_commands.json --std=c++11 2> cppcheck.log
+      - name: Add CppCheck result to job summary
+        run: |
+          echo "## Cppcheck output" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "$(cat cppcheck.log)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
       - name: Upload log file
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Just a small addition to be able to read the results directly from within GitHub:

https://github.com/lancaster-university/microbit-v2-samples/actions/runs/5716774615
<img width="2036" alt="image" src="https://github.com/lancaster-university/microbit-v2-samples/assets/29712657/85f02f01-f75d-4e3d-920b-186567dcbadd">

@JohnVidler btw, maybe we should move/copy this workflow to codal-microbit-v2, as that's where most of the commits will be.