### PR TITLE
VSCode: Update OpenOCD launch.json to point to SVD fine & increase SWD speed.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,9 @@
             "load build/MICROBIT",
             "enable breakpoint",
             "monitor reset"
+          ],
+          "openOCDLaunchCommands": [
+            "adapter speed 8000"
           ]
       }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,7 @@
             "target/nrf52.cfg"
           ],
           "interface": "swd",
+          "svdFile": "libraries/codal-nrf52/nrfx/mdk/nrf52833.svd",
           "preLaunchCommands": [
             "load build/MICROBIT",
             "enable breakpoint",


### PR DESCRIPTION
nRF52 SWD max frequency is 8 MHz and setting this value makes it a bit faster to launch and respond to commands.