### PR TITLE
VSCode: Add Cortex Debug launch config to attach to a running target.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,24 @@
           "openOCDLaunchCommands": [
             "adapter speed 8000"
           ]
+      },
+      {
+          "name": "(attach) micro:bit OpenOCD Cortex Debug",
+          "cwd": "${workspaceFolder}",
+          "executable": "build/MICROBIT",
+          "request": "attach",
+          "type": "cortex-debug",
+          "servertype": "openocd",
+          "configFiles": [
+            "interface/cmsis-dap.cfg",
+            "target/nrf52.cfg"
+          ],
+          "interface": "swd",
+          "svdFile": "libraries/codal-nrf52/nrfx/mdk/nrf52833.svd",
+          "preAttachCommands": [],
+          "openOCDLaunchCommands": [
+            "adapter speed 8000"
+          ]
       }
   ]
 }


### PR DESCRIPTION
@JohnVidler This might also be helpful when debugging CODAL and/or pxt C++ code with MakeCode projects (the TS user code doesn't have symbols for the debugger, but you can still inspect the C++ stack trace or add breakpoint to the C++ sources).