### PR TITLE
Update CMakeLists.txt to add DEVICE_DAL_VERSION to codal_extra_definitions.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,11 @@ EXTRACT_JSON_ARRAY(device "device\.config\." DEVICE_FIELDS DEVICE_VALUES)
 UNIQUE_JSON_KEYS(CODAL_FIELDS CODAL_VALUES DEVICE_FIELDS DEVICE_VALUES FINAL_FIELDS FINAL_VALUES)
 FORM_DEFINITIONS(FINAL_FIELDS FINAL_VALUES CODAL_DEFINITIONS)
 
+# If the CODAL target version is stored in target-locked.json add it to the DEVICE_DAL_VERSION define
+if (DEFINED device.snapshot_version)
+    set(CODAL_DEFINITIONS "${CODAL_DEFINITIONS} #define DEVICE_DAL_VERSION\t \"${device.snapshot_version}\"\n")
+endif()
+
 # extract any CMAKE definitions specified in the target.json object, and set as native cmake vars
 # cmake definitions require special handling as types are not safe in cmake, any semi-colon would need escaped, which would be ugly.
 foreach(var ${device})


### PR DESCRIPTION
Together with this PR:
- https://github.com/lancaster-university/codal-microbit-v2/pull/413

Resolves https://github.com/lancaster-university/codal-microbit-v2/issues/138.
- https://github.com/lancaster-university/codal-microbit-v2/issues/138

This only works when the CMake build system is reading `target-locked.json` instead of `target.json`, which should be most of the time. The only way in which it uses `target.json` is when the codal.json flag has `target.dev` set.

With both PRs this test programme prints the codal-microbit-v2 latest tag in all entries (basically whatever is in [codal-microbit-v2/target-locked.json#L74](https://github.com/lancaster-university/codal-microbit-v2/blob/master/target-locked.json#L74):

```cpp
int main() {
    uBit.init();

    uBit.serial.printf("MICROBIT_DAL_VERSION: %s\n", MICROBIT_DAL_VERSION);
    uBit.serial.printf("DEVICE_DAL_VERSION: %s\n", DEVICE_DAL_VERSION);
    uBit.serial.printf("microbit_dal_version(): %s\n", microbit_dal_version());
    uBit.serial.printf("uBit.getVersion(): %s\n", uBit.getVersion());

    while (true);
}
```