### PR TITLE
CI: Update the version of the GH Actions used.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}, gcc ${{ matrix.gcc }}, cmake ${{ matrix.cmake || 'latest'}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Setup arm-none-eabi-gcc ${{ matrix.gcc }}
@@ -27,7 +27,7 @@ jobs:
         with:
           release: ${{ matrix.gcc }}
       - name: Setup CMake ${{ matrix.cmake }}
-        uses: jwlawson/actions-setup-cmake@v1
+        uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: ${{ matrix.cmake }}
       - name: Install Ninja via PyPI
@@ -41,9 +41,9 @@ jobs:
       - name: Build default project using build.py
         run: python build.py
       - name: Upload hex file
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
-          name: build-py-${{ matrix.os }}
+          name: MICROBIT-${{ matrix.os }}-gcc-${{ matrix.gcc }}-cmake-${{ matrix.cmake || 'latest' }}
           path: MICROBIT.hex
       - name: Prepare BLE example
         run: |
@@ -56,7 +56,7 @@ jobs:
       - name: Build BLE project using build.py
         run: python build.py --clean
       - name: Upload BLE hex file
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
-          name: build-py-BLE-${{ matrix.os }}
+          name: MICROBIT-BLE-${{ matrix.os }}-gcc-${{ matrix.gcc }}-cmake-${{ matrix.cmake || 'latest' }}
           path: MICROBIT.hex

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Run CppCheck against the codebase + libraries
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install CppCheck
         run: |
           sudo apt-get update
@@ -22,7 +22,7 @@ jobs:
         with:
           release: latest
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1
+        uses: jwlawson/actions-setup-cmake@v2
       - name: Build default project using build.py
         run: python build.py
       - name: Run CppCheck
@@ -34,7 +34,7 @@ jobs:
           echo "## Cppcheck output" >> $GITHUB_STEP_SUMMARY
           echo "$(cat cppcheck.md)" >> $GITHUB_STEP_SUMMARY
       - name: Upload log file
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: cppcheck.md
           path: cppcheck.md

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build using the Docker image
       env:
         DOCKER_BUILDKIT: 1
@@ -19,7 +19,7 @@ jobs:
     - name: Directory Listing
       run: ls -al
     - name: Upload hex file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: Export from Docker
         path: out/MICROBIT.hex

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Build against Ubuntu-20.04 for release assets
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install CppCheck
         run: |
           sudo apt-get update
@@ -22,7 +22,7 @@ jobs:
           release: latest
       
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1
+        uses: jwlawson/actions-setup-cmake@v2
       
       - name: Build default project using build.py
         run: python build.py
@@ -33,4 +33,3 @@ jobs:
         with:
           file: "build/*.a"
           update_latest_release: true
-        


### PR DESCRIPTION
Some old versions are deprecated and will stop working soon, others simply show warnings about using a deprecated version of nodejs.