### PR TITLE
Change 'as' to 'AS' in Dockerfile to remove FromAsCasting Warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as builder
+FROM ubuntu:18.04 AS builder
 
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
change 'as' to 'AS' in the Dockerfile to remove the FromAsCasting warning and to improve readability 