### PR TITLE
Add `-Werror=return-type` to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ if("${device.cpu_opts}" STRGREATER "")
     set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${device.cpu_opts}")
 endif()
 
-set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra -Wno-unused-parameter")
+set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra -Wno-unused-parameter -Werror=return-type")
 
 # asm
 if("${device.asm_flags}" STRGREATER "")


### PR DESCRIPTION
In C++ (but not C), when a return statement is omitted in a function that is supposed to return an `int`, it is undefined behaviour, even if the return value isn't being accessed by the caller. A warning is produced for this (`-Wreturn-type`), but it's somewhat buried among the other warnings produced by the libraries in this repository ([microbit-v2-samples](https://github.com/lancaster-university/microbit-v2-samples)).

Here's an example:

```cpp
#include "MicroBit.h"

MicroBit uBit; // Initialize the MicroBit object

int exampleFunction1() {
    uBit.serial.printf("exampleFunction1()\n");
    // return 0; // This return statement is commented out
}

int exampleFunction2() {
    uBit.serial.printf("exampleFunction2()\n");
    // return 0; // This return statement is commented out
}

int exampleFunction3() {
    uBit.serial.printf("exampleFunction3()\n");
    // return 0; // This return statement is commented out
}

int main() {
    uBit.init();

    uBit.serial.printf("main()\n");

    exampleFunction1();
    exampleFunction2();
    exampleFunction3();
    exampleFunction2();
    exampleFunction1();
}
```

#### Serial Output With Return Statements:
```
main()
exampleFunction1()
exampleFunction2()
exampleFunction3()
exampleFunction2()
exampleFunction1()
```

#### Serial Output Without Return Statements:
When the return statements are commented out, you get warnings such as the following:
```
microbit-v2-samples/source/main.cpp: In function 'int exampleFunction1()':
microbit-v2-samples/source/main.cpp:8:1: warning: no return statement in function returning non-void [-Wreturn-type]
 8 | }
   | ^
```

And the program outputs:
```
main()
exampleFunction1()
main()
exampleFunction1()
main()
exampleFunction1()
main()
exampleFunction1()
...
```

It looks like it's "flowing off the end of the function" and running whatever is next in memory (in this case, instructions from the `main` function), which is supported by the fact that the behaviour can change when commenting out seemingly unrelated code.

The misunderstanding comes from a belief that in non-void functions, failing to return is fine as long as the return value isn't used by the caller. This isn't the case however, and it's the kind of undefined behaviour that can lead to what we saw above. To add to the confusion, [this article](https://mcopik.github.io/blog/2016/Return-statements-undefined-behaviour/?form=MG0AV3) suggests this is only undefined behaviour in C++, and not in C which students are taught.

[A different article](https://dzone.com/articles/undefined-behavior-due-to-the-absence-of-a-return?form=MG0AV3) goes into more detail.

#### Proposed Solution

This problem is symptomatic of a greater issue, which is the long list of warnings produced by the libraries in the `microbit-v2-samples` repo leading to people becoming "warning blind".

To remediate just this specific issue however, we can change the warning to an error by adding `-Werror=return-type` to `CMakeLists.txt`. This would stop compilation if there's no return statement in a function that should return a non-void value. More specifically (from the [gcc warning options list](https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Warning-Options.html)):

```
-Wreturn-type
    Warn whenever a function is defined with a return-type that defaults to int. Also warn about any
    return statement with no return-value in a function whose return-type is not void.

    For C, also warn if the return type of a function has a type qualifier such as const. Such a
    type qualifier has no effect, since the value returned by a function is not an lvalue. ISO C
    prohibits qualified void return types on function definitions, so such return types always receive
    a warning even without this option.

    For C++, a function without return type always produces a diagnostic message, even when
    -Wno-return-type is specified. The only exceptions are `main` and functions defined in system
    headers.

    This warning is enabled by `-Wall`.
```

The repository still builds with `-Werror=return-type`, but adding it may cause someone else's code that depends on this repository to stop building with the new repository version.