### PR TITLE
CMake: Add option (v3.24+) to force Ninja output to be coloured.

### DIFF
--- a/utils/cmake/colours.cmake
+++ b/utils/cmake/colours.cmake
@@ -17,3 +17,8 @@ if(NOT WIN32)
   set(BoldCyan    "${Esc}[1;36m")
   set(BoldWhite   "${Esc}[1;37m")
 endif()
+
+# Ninja builds are not coloured, compilers detect their output being piped and
+# remove it. This makes CMake > 3.24 add extra compiler flags to force colour
+# and has no effect on older CMake versions
+set(CMAKE_COLOR_DIAGNOSTICS On)


### PR DESCRIPTION
Ninja builds are not coloured, ninja internally pipes the compiler output, which the compilers detect and remove the text formatting:
https://github.com/ninja-build/ninja/wiki/FAQ#why-does-my-program-with-colored-output-not-have-color-under-ninja

This option makes CMake > 3.24 add extra compiler flags to force colour and has no effect on older CMake versions.

Before:
<img width="1306" alt="Screenshot 2024-12-13 at 18 51 51" src="https://github.com/user-attachments/assets/8f5b737b-eb49-4ea3-9cc7-6d0eda41d103" />

After:
<img width="1316" alt="Screenshot 2024-12-13 at 18 52 40" src="https://github.com/user-attachments/assets/129959c3-0a6f-4288-a068-5f708ae823d0" />

