### PR TITLE
CI: Reduce the min GCC version used to match what MakeCode (PXT) uses.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-13, windows-2019]
-        gcc: ['7-2017-q4', 'latest']
+        gcc: ['6-2016-q4', 'latest']  # Min version 6.2 as used in pext/yotta:latest docker image
         cmake: ['3.6.0', '']  # Empty string installs the latest CMake release
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/source/samples/MicrophoneTest.cpp
+++ b/source/samples/MicrophoneTest.cpp
@@ -1,10 +1,10 @@
-#include <stdio.h>
 #include "MicroBit.h"
 #include "SerialStreamer.h"
 #include "StreamNormalizer.h"
 #include "LevelDetector.h"
 #include "LevelDetectorSPL.h"
 #include "Tests.h"
+#include <stdio.h>
 
 static NRF52ADCChannel *mic = NULL;
 static SerialStreamer *streamer = NULL;


### PR DESCRIPTION
It also fixes an issue building with GCC v6 when stdio.h is included before MicroBit.h
This is because stdio packed in arm-none-eabi-gcc (probably newlibc? can't remember when they changed the default) seems to have macro for `putc(int, FILE*)` to cause havoc on `putc` methods in multiple CODAL classes like serial.

This issue was not triggered in the pxt-microbit builds using `pext/yotta:lattest` because the include line is in one of the file included in this repo, which pxt-microbit doesn't build.