### PR TITLE
RFC: Dockerfile: updated to use ubuntu:24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,42 @@
-FROM ubuntu:18.04 AS builder
+# To build an image:
+#   $ podman build --platform linux/amd64 -t microbit -f Dockerfile .
+#
+# To start and enter that image:
+#   $ podman run  --tty --rm --interactive --volume "$(pwd)":/workspace --workdir /workspace microbit
+#
+# Inside the image you can run build.py to build the project. The
+# current directory from where you run podman will be shared into the
+# image under /workspace, which will also be the default directory
+# when running the image. This means that the built MICROBIT.hex file
+# will be available in the source folder outside the image.
+
+FROM ubuntu:24.04 AS builder
 
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
-      software-properties-common && \
-    add-apt-repository -y ppa:team-gcc-arm-embedded/ppa && \
-    apt-get update -qq && \
-    apt-get install -y --no-install-recommends \
-      git make cmake python3 \
-      gcc-arm-embedded && \
+      software-properties-common \
+      git \
+      make \
+      cmake \
+      python3 \
+      python3-pip \
+      gcc-arm-none-eabi \
+      binutils-arm-none-eabi \
+      libnewlib-arm-none-eabi \
+      libstdc++-arm-none-eabi-newlib \
+      ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Project sources volume should be mounted at /app
-COPY . /opt/microbit-samples
-WORKDIR /opt/microbit-samples
+# COPY . /opt/microbit-samples
+# WORKDIR /opt/microbit-samples
 
-RUN python3 build.py
+# RUN python3 build.py
 
-FROM scratch AS export-stage
-COPY --from=builder /opt/microbit-samples/MICROBIT.bin .
-COPY --from=builder /opt/microbit-samples/MICROBIT.hex .
+# FROM scratch AS export-stage
+# COPY --from=builder /opt/microbit-samples/MICROBIT.bin .
+# COPY --from=builder /opt/microbit-samples/MICROBIT.hex .
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
i'm very new to the ecosystem, and i've just compiled my first firmware for the microbit.

with that in mind, i'm not sure how this Dockerfile is used in the CI. i much prefer the new `--volume` based sharing of the current directory while developing, and i never used the `FROM scratch AS export-stage` stuff. in general i'm not a docker expert.

please advise whether this is fine, or if i should rather undo that part and learn the `FROM scratch AS export-stage` stuff. i'll modify the PR in that case.

### background info

my ultimate goal is to compile Lua 5.1, and i'm planning to use this repo as a starting point for my first attempt using CODAL. if it fails, or is too cumbersome, then plan B is to look into building on top of Zephyr.

FWIW, i've done something like this before, years ago: https://github.com/attila-lendvai/moonboots