### PR TITLE
Add macOS build support and guide

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,19 +1,14 @@
 {
     "configurations": [
         {
-            "name": "Linux",
-            "includePath": [
-                "${workspaceFolder}/source/**",
-                "${workspaceFolder}/libraries/**",
-                "${workspaceFolder}/utils/cmake/**",
-                "${workspaceFolder}/build/libraries/**"
-            ],
-            "defines": [],
-            "compilerPath": "/usr/bin/arm-none-eabi-g++",
-            "compilerArgs": ["-DNRF52833_XXAA"],
-            "cStandard": "c11",
+            "name": "mac-CODAL-ARM",
+            "compilerPath": "/Applications/ArmGNUToolchain/15.2.rel1/arm-none-eabi/bin/arm-none-eabi-g++",
+            "cStandard": "c17",
             "cppStandard": "c++11",
-            "intelliSenseMode": "gcc-arm"
+            "intelliSenseMode": "gcc-arm",
+            "compileCommands": [
+                "${workspaceFolder}/build/compile_commands.json"
+            ]
         }
     ],
     "version": 4

--- a/README.md
+++ b/README.md
@@ -1,75 +1,84 @@
-# microbit-v2-samples
+# macOS Compatible CODAL Compilation
+This repo provides a guide to fixing compilation for [CODAL](https://github.com/lancaster-university/microbit-v2-samples) on macOS hosts.
 
-[![Native Build Status](https://github.com/lancaster-university/microbit-v2-samples/actions/workflows/build.yml/badge.svg)](https://github.com/lancaster-university/microbit-v2-samples/actions/workflows/build.yml) [![Docker Build Status](https://github.com/lancaster-university/microbit-v2-samples/actions/workflows/docker-image.yml/badge.svg)](https://github.com/lancaster-university/microbit-v2-samples/actions/workflows/docker-image.yml)
+❗️This guide assumes you are using the latest CODAL folder, and that you are working from within it. File paths that have no explicit root are relative to the CODAL folder.
 
-This repository provides the necessary tooling to compile a C/C++ CODAL program for the micro:bit V2 and generate a HEX file that can be downloaded to the device.
+# Fix building
+Make sure the usual dependencies are installed first:
+- [Git](https://git-scm.com) or `brew install git`
+- [CMake](https://cmake.org/download/) or `brew install cmake`
+- [Python 3](https://www.python.org/downloads/) or `brew install python3`
 
-## Raising Issues
-Any issues regarding the micro:bit are gathered on the [lancaster-university/codal-microbit-v2](https://github.com/lancaster-university/codal-microbit-v2) repository. Please raise yours there too.
+## Install Arm Toolchain
+macOS requires the webpage GNU Arm Embedded Toolchain download, rather than the default `arm-none-eabi` brew package as this misses some built-in libraries.
 
-# Installation
-You need some open source pre-requisites to build this repo. You can either install these tools yourself, or use the docker image provided below.
+- [GNU Arm Embedded Toolchain for macOS](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads#:~:text=arm%2Dgnu%2Dtoolchain%2D15.2.rel1%2Ddarwin%2Darm64%2Darm%2Dnone%2Deabi.tar.xz) 
+    -  **Dont use the brew package**
+    - Select correct architecture: Apple Silicon (arm64) or Intel (x86_64)
+    - Use the **pkg** installer. ~1GB extracted in: `/Applications/ArmGNUToolchain/15.2.rel1/arm-none-eabi/`
+        - Using the tarball is possible but requires additional setup to add the toolchain to your PATH and set up the necessary environment variables.
 
-- [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
-- [Git](https://git-scm.com)
-- [CMake](https://cmake.org/download/)
-- [Python 3](https://www.python.org/downloads/)
+⚠️ Arm Toolchain 15.2.rel1 is the latest version at the time of writing. If you install a different version, make sure to change paths from `"/Applications/ArmGNUToolchain/15.2.rel1/arm-none-eabi"`
+## Update toolchain file
+*Already included in this repo*
+1. `utils/cmake/toolchains/ARM_GCC/toolchain.cmake`
+```json
+# Define Official ARM GNU Embedded Toolchain path (macOS)
+set(ARM_TOOLCHAIN_PATH "/Applications/ArmGNUToolchain/15.2.rel1/arm-none-eabi")
 
-We use Ubuntu Linux for most of our tests. You can also install these tools easily through the package manager:
+# Look for toolchain binaries in the official installation first, then system PATH
+find_program(ARM_NONE_EABI_RANLIB arm-none-eabi-ranlib PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_AR arm-none-eabi-ar PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_GCC arm-none-eabi-gcc PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_GPP arm-none-eabi-g++ PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_OBJCOPY arm-none-eabi-objcopy PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_SIZE arm-none-eabi-size PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+
+# If not found in the official path, try system PATH
+if(NOT ARM_NONE_EABI_GCC)
+    find_program(ARM_NONE_EABI_RANLIB arm-none-eabi-ranlib)
+    find_program(ARM_NONE_EABI_AR arm-none-eabi-ar)
+    find_program(ARM_NONE_EABI_GCC arm-none-eabi-gcc)
+    find_program(ARM_NONE_EABI_GPP arm-none-eabi-g++)
+    find_program(ARM_NONE_EABI_OBJCOPY arm-none-eabi-objcopy)
+    find_program(ARM_NONE_EABI_SIZE arm-none-eabi-size)
+endif()
+
+# For cross-compilation on macOS, disable macOS-specific settings
+# CMAKE_OSX_SYSROOT should not be set for ARM cross-compilation
+set(CMAKE_OSX_SYSROOT "")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "")
+
+set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_SYSTEM_VERSION "2.0.0")
+
+# Set sysroot for cross-compilation (empty for ARM bare-metal)
+set(CMAKE_SYSROOT "")
+
+set(CODAL_TOOLCHAIN "ARM_GCC")
+
+if(CMAKE_VERSION VERSION_LESS "3.5.0")
+    include(CMakeForceCompiler)
+    cmake_force_c_compiler("${ARM_NONE_EABI_GCC}" GNU)
+    cmake_force_cxx_compiler("${ARM_NONE_EABI_GPP}" GNU)
+else()
+    # from 3.5 the force_compiler macro is deprecated: CMake can detect
+    # arm-none-eabi-gcc as being a GNU compiler automatically
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+    set(CMAKE_C_COMPILER "${ARM_NONE_EABI_GCC}")
+    set(CMAKE_CXX_COMPILER "${ARM_NONE_EABI_GPP}")
+endif()
+
+SET(CMAKE_AR "${ARM_NONE_EABI_AR}" CACHE FILEPATH "Archiver")
+SET(CMAKE_RANLIB "${ARM_NONE_EABI_RANLIB}" CACHE FILEPATH "rlib")
+set(CMAKE_CXX_OUTPUT_EXTENSION ".o")
 
 ```
-    sudo apt install gcc
-    sudo apt install git
-    sudo apt install cmake
-    sudo apt install gcc-arm-none-eabi binutils-arm-none-eabi
-```
 
-## Yotta
-For backwards compatibility with [microbit-samples](https://github.com/lancaster-university/microbit-samples) users, we also provide a yotta target for this repository.
-
-## Docker
-You can use the [Dockerfile](https://github.com/lancaster-university/microbit-v2-samples/blob/master/Dockerfile) provided to build the samples, or your own project sources, without installing additional dependencies.
-
-Run the following command to build the image locally; the .bin and .hex files from a successful compile will be placed in a new `out/` directory:
-
-```
-    docker build -t microbit-tools --output out .
-```
-
-To omit the final output stage (for CI, for example) run without the `--output` arguments:
-
-```
-    docker build -t microbit-tools .
-```
-
-# Building
-- Clone this repository
-- In the root of this repository type `python build.py`
-- The hex file will be built `MICROBIT.hex` and placed in the root folder.
+### Running `python3 build.py` should now work fine
 
 # Developing
 You will find a simple main.cpp in the `source` folder which you can edit. CODAL will also compile any other C/C++ header files our source files with the extension `.h .c .cpp` it finds in the source folder.
 
 The `samples` folder contains a number of simple sample programs that utilise you may find useful.
 
-## Developer codal.json
-
-There is an example `coda.dev.json` file which enables "developer builds" (clones dependencies from the latest commits, instead of the commits locked in the `codal-microbit-v2` tag), and adds extra CODAL flags that enable debug data to be printed to serial.
-To use it, simply copy the additional json entries into your `codal.json` file, or you can replace the file completely (`mv coda.dev.json codal.json`).
-
-# Debugging
-If you are using Visual Studio Code, there is a working debugging environment already set up for you, allowing you to set breakpoints and observe the micro:bit's memory. To get it working, follow these steps:
-
-1. Install either [OpenOCD](http://openocd.org) or [PyOCD](https://github.com/pyocd/pyOCD).
-2. Install the [`marus25.cortex-debug` VS Code extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug).
-3. Build your program.
-4. Click the Run and Debug option in the toolbar.
-5. Two debugging options are provided: one for OpenOCD, and one for PyOCD. Select the correct one depending on the debugger you installed.
-
-This should launch the debugging environment for you. To set breakpoints, you can click to the left of the line number of where you want to stop.
-
-# Compatibility
-This repository is designed to follow the principles and APIs developed for the first version of the micro:bit. We have also included a compatibility layer so that the vast majority of C/C++ programs built using [microbit-dal](https://www.github.com/lancaster-university/microbit-dal) will operate with few changes.
-
-# Documentation
-API documentation is embedded in the code using doxygen. We will produce integrated web-based documentation soon.

--- a/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
+++ b/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
@@ -1,6 +1,6 @@
 # Official ARM GNU Embedded Toolchain path (macOS)
 if(CMAKE_HOST_APPLE) # Set location of ARM GNU Embedded Toolchain for macOS
-set(ARM_TOOLCHAIN_PATH "/Applications/ArmGNUToolchain/15.2.rel1/arm-none-eabi")
+    set(ARM_TOOLCHAIN_PATH "/Applications/ArmGNUToolchain/15.2.rel1/arm-none-eabi")
 endif()
 
 # Look for toolchain binaries in the official installation first, then system PATH

--- a/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
+++ b/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
@@ -1,5 +1,7 @@
 # Official ARM GNU Embedded Toolchain path (macOS)
+if(CMAKE_HOST_APPLE) # Set location of ARM GNU Embedded Toolchain for macOS
 set(ARM_TOOLCHAIN_PATH "/Applications/ArmGNUToolchain/15.2.rel1/arm-none-eabi")
+endif()
 
 # Look for toolchain binaries in the official installation first, then system PATH
 find_program(ARM_NONE_EABI_RANLIB arm-none-eabi-ranlib PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)

--- a/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
+++ b/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
@@ -1,15 +1,34 @@
-find_program(ARM_NONE_EABI_RANLIB arm-none-eabi-ranlib)
-find_program(ARM_NONE_EABI_AR arm-none-eabi-ar)
-find_program(ARM_NONE_EABI_GCC arm-none-eabi-gcc)
-find_program(ARM_NONE_EABI_GPP arm-none-eabi-g++)
-find_program(ARM_NONE_EABI_OBJCOPY arm-none-eabi-objcopy)
-find_program(ARM_NONE_EABI_SIZE arm-none-eabi-size)
+# Official ARM GNU Embedded Toolchain path (macOS)
+set(ARM_TOOLCHAIN_PATH "/Applications/ArmGNUToolchain/15.2.rel1/arm-none-eabi")
 
-set(CMAKE_OSX_SYSROOT "/")
+# Look for toolchain binaries in the official installation first, then system PATH
+find_program(ARM_NONE_EABI_RANLIB arm-none-eabi-ranlib PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_AR arm-none-eabi-ar PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_GCC arm-none-eabi-gcc PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_GPP arm-none-eabi-g++ PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_OBJCOPY arm-none-eabi-objcopy PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+find_program(ARM_NONE_EABI_SIZE arm-none-eabi-size PATHS "${ARM_TOOLCHAIN_PATH}/bin" NO_DEFAULT_PATH)
+
+# If not found in the official path, try system PATH
+if(NOT ARM_NONE_EABI_GCC)
+    find_program(ARM_NONE_EABI_RANLIB arm-none-eabi-ranlib)
+    find_program(ARM_NONE_EABI_AR arm-none-eabi-ar)
+    find_program(ARM_NONE_EABI_GCC arm-none-eabi-gcc)
+    find_program(ARM_NONE_EABI_GPP arm-none-eabi-g++)
+    find_program(ARM_NONE_EABI_OBJCOPY arm-none-eabi-objcopy)
+    find_program(ARM_NONE_EABI_SIZE arm-none-eabi-size)
+endif()
+
+# For cross-compilation on macOS, disable macOS-specific settings
+# CMAKE_OSX_SYSROOT should not be set for ARM cross-compilation
+set(CMAKE_OSX_SYSROOT "")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "")
 
 set(CMAKE_SYSTEM_NAME "Generic")
 set(CMAKE_SYSTEM_VERSION "2.0.0")
+
+# Set sysroot for cross-compilation (empty for ARM bare-metal)
+set(CMAKE_SYSROOT "")
 
 set(CODAL_TOOLCHAIN "ARM_GCC")
 


### PR DESCRIPTION
Modifies toolchain file to allow building on macOS hosts with a custom compiler path, and improves locating of arm embedded compiler binaries.
Includes a guide for the install process and how to modify existing CODAL environments for compatibility.