### PR TITLE
Add devshell and helix config

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Makefile
 pxtapp
 buildcache.json
 *.pyc
+.cache
+.direnv

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,11 @@
+[language-server.clangd]
+command = "clangd"
+args = ["--query-driver=/nix/store/*/bin/arm-none-eabi-*", "--background-index", "--header-insertion=never"]
+
+[[language]]
+name = "cpp"
+language-servers = ["clangd"]
+
+[[language]]
+name = "c"
+language-servers = ["clangd"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ endif()
 set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_CXX_COMPILER_WORKS 1)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 
 #read our config file...
 file(READ "./codal.json" codal_json)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782233679,
+        "narHash": "sha256-QyuGP5+QOtmXpy4i2X4DhBVBaySBdDKQEhqKcphcp34=",
+        "owner": "NixOs",
+        "repo": "nixpkgs",
+        "rev": "667d5cf1c59585031d743c78b394b0a647537c35",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOs",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Dev environment for CODAL";
+
+  inputs = {
+    nixpkgs.url = "github:NixOs/nixpkgs/nixos-26.05";
+  };
+
+  outputs = { self, nixpkgs }: 
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forEachSupportedSystem = f:
+        nixpkgs.lib.genAttrs supportedSystems
+          (system: f {
+            pkgs = import nixpkgs { inherit system; };
+          });
+    in
+    {
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = [
+            # Build toolchain
+            pkgs.gcc-arm-embedded-13
+            pkgs.git
+            pkgs.cmake
+            pkgs.python3
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
This PR adds a nix devshell for the project and config for the Helix IDE to correctly configure clangd as its LSP.

The devshell provides an environment with version-locked tooling, identical on any of the supported systems (linux and macos in x86-64 and aarch64 flavours).
To use, first install nix on your machine. Then within the repo root run `nix develop`. This will pull the specified packages into the nix store and drop you into a shell with the tools available. Pressing Ctrl-D will end the shell session, and the tools will no longer be accessible.

This can also be automated by installing direnv and nix-direnv. Once this is done, run `direnv allow` from the repo root, and from this point on the devshell will be entered automatically on entering the repo directory, and left again when exiting the directory. This has the added benefit of keeping your shell profile active.

The secondary part of this PR is to add config for Helix (my IDE of choice). It adds a flag to CMake to export the compile commands on build, which clangd uses for the build context. `python build.py` will need to be run once to generate the compile commands, and from this point clangd should have everything it needs.